### PR TITLE
feat: Accept requests asking for a server list with fields

### DIFF
--- a/internal/api/master/browser/browser_test.go
+++ b/internal/api/master/browser/browser_test.go
@@ -35,6 +35,7 @@ func TestMasterBrowserService_HandleRequest_Parse(t *testing.T) {
 					"password", "gamever", "statsenabled",
 				},
 				"gametype='VIP Escort' and gamever='1.1'",
+				[]byte{0x00, 0x00, 0x00, 0x00},
 				testutils.GenBrowserChallenge8,
 				testutils.CalcReqLength,
 			),
@@ -48,6 +49,17 @@ func TestMasterBrowserService_HandleRequest_Parse(t *testing.T) {
 					"password", "gamever", "statsenabled",
 				},
 				"",
+				[]byte{0x00, 0x00, 0x00, 0x00},
+				testutils.GenBrowserChallenge8,
+				testutils.CalcReqLength,
+			),
+		},
+		{
+			name: "positive case - list type 1 is accepted",
+			payload: testutils.PackBrowserRequest(
+				[]string{"hostname"},
+				"",
+				[]byte{0x00, 0x00, 0x00, 0x01},
 				testutils.GenBrowserChallenge8,
 				testutils.CalcReqLength,
 			),
@@ -61,6 +73,7 @@ func TestMasterBrowserService_HandleRequest_Parse(t *testing.T) {
 					"password", "gamever", "statsenabled",
 				},
 				"gametype='VIP Escort' and gamever='1.1",
+				[]byte{0x00, 0x00, 0x00, 0x00},
 				testutils.GenBrowserChallenge8,
 				testutils.CalcReqLength,
 			),
@@ -70,6 +83,7 @@ func TestMasterBrowserService_HandleRequest_Parse(t *testing.T) {
 			payload: testutils.PackBrowserRequest(
 				[]string{},
 				"gametype='VIP Escort' and gamever='1.1'",
+				[]byte{0x00, 0x00, 0x00, 0x00},
 				testutils.GenBrowserChallenge8,
 				testutils.CalcReqLength,
 			),
@@ -84,6 +98,7 @@ func TestMasterBrowserService_HandleRequest_Parse(t *testing.T) {
 					"password", "gamever", "statsenabled",
 				},
 				"",
+				[]byte{0x00, 0x00, 0x00, 0x00},
 				func() []byte {
 					return testutils.GenBrowserChallenge(7)
 				},
@@ -111,6 +126,7 @@ func TestMasterBrowserService_HandleRequest_Parse(t *testing.T) {
 			payload: testutils.PackBrowserRequest(
 				[]string{"hostname"},
 				"",
+				[]byte{0x00, 0x00, 0x00, 0x00},
 				testutils.GenBrowserChallenge8,
 				testutils.CalcReqLength,
 			)[:30],
@@ -121,6 +137,7 @@ func TestMasterBrowserService_HandleRequest_Parse(t *testing.T) {
 			payload: testutils.PackBrowserRequest(
 				[]string{"hostname"},
 				"",
+				[]byte{0x00, 0x00, 0x00, 0x00},
 				testutils.GenBrowserChallenge8,
 				testutils.WithBrowserChallengeLength(400),
 			),
@@ -131,6 +148,7 @@ func TestMasterBrowserService_HandleRequest_Parse(t *testing.T) {
 			payload: testutils.PackBrowserRequest(
 				[]string{"hostname"},
 				"",
+				[]byte{0x00, 0x00, 0x00, 0x00},
 				testutils.GenBrowserChallenge8,
 				testutils.WithBrowserChallengeLength(30),
 			),
@@ -141,8 +159,31 @@ func TestMasterBrowserService_HandleRequest_Parse(t *testing.T) {
 			payload: testutils.PackBrowserRequest(
 				[]string{"hostname"},
 				"",
+				[]byte{0x00, 0x00, 0x00, 0x00},
 				testutils.GenBrowserChallenge8,
 				testutils.WithBrowserChallengeLength(0),
+			),
+			wantErr: browsing.ErrInvalidRequestFormat,
+		},
+		{
+			name: "invalid list type option",
+			payload: testutils.PackBrowserRequest(
+				[]string{"hostname"},
+				"",
+				[]byte{0x00, 0x00, 0x00, 0x20},
+				testutils.GenBrowserChallenge8,
+				testutils.CalcReqLength,
+			),
+			wantErr: browsing.ErrInvalidRequestFormat,
+		},
+		{
+			name: "invalid option mask length",
+			payload: testutils.PackBrowserRequest(
+				[]string{"hostname"},
+				"",
+				[]byte{0x00, 0x00, 0x00, 0x00, 0x00},
+				testutils.GenBrowserChallenge8,
+				testutils.CalcReqLength,
 			),
 			wantErr: browsing.ErrInvalidRequestFormat,
 		},

--- a/internal/testutils/browsing.go
+++ b/internal/testutils/browsing.go
@@ -38,6 +38,7 @@ func CalcReqLength(req []byte) int {
 func PackBrowserRequest(
 	fields []string,
 	filters string,
+	options []byte,
 	getChallenge func() []byte,
 	getLengthFunc func([]byte) int,
 ) []byte {
@@ -70,8 +71,9 @@ func PackBrowserRequest(
 	req = append(req, []byte(fieldsJoined)...)
 	req = append(req, 0x00)
 
-	// last 4 bytes, int 32, options; options bitmask - alwayws 0 for swat
-	req = append(req, []byte{0x00, 0x00, 0x00, 0x00}...)
+	// last 4 bytes, int 32, options; options bitmask - always 0 for swat if the request is coming from the game,
+	// since it requests a plain server list. However, tools like gslist send 1 (server list with fields)
+	req = append(req, options...)
 
 	// calculate the length and insert the number into the first two bytes as an unsigned short
 	binary.BigEndian.PutUint16(req[:2], uint16(getLengthFunc(req)))
@@ -122,6 +124,7 @@ func SendBrowserRequest(
 			"password", "gamever", "statsenabled",
 		},
 		filters,
+		[]byte{0x00, 0x00, 0x00, 0x00},
 		func() []byte {
 			return challenge[:]
 		},

--- a/pkg/gamespy/browsing/browsing.go
+++ b/pkg/gamespy/browsing/browsing.go
@@ -70,10 +70,7 @@ func (req *Request) parse() error {
 	if err := req.parseFields(); err != nil {
 		return err
 	}
-	if err := req.validateOptionsMask(); err != nil {
-		return err
-	}
-	return nil
+	return req.validateOptionsMask()
 }
 
 func (req *Request) parseChallenge() error {


### PR DESCRIPTION
Hey Sergei,

Thanks for making this open source!

I was messing about trying to query SWAT4 servers from this master server with [gslist](http://aluigi.altervista.org/papers.htm#gslist), a GameSpy query tool developed way back in the day by Luigi Auriemma. However, `gslist` was not able to fetch a server list. I compared the payloads and noticed that `gslist` always sends the last byte of the option mask as `1`. The game sends it as `0` and the current master server implementation validates the request accordingly.

According to [a comment](https://github.com/cetteup/gslist/blob/ef4820ac27a1c97a6d47b8b44dd0a13344085ee9/src/gsmyfunc.h#L406) from Luigi, `0` means the client is requesting a plain server list (ip and port only I assume). A request with `1` would indicate that the client wants a server list with fields such as `\hostname` etc.

I have updated my fork of `gslist` today so I can set that byte directly before noticing the code for the master server is open source as well. So, all my changes here aim to achieve is that an option mask of `0x00 0x00 0x00 0x01` will be accepted as well as one with `0x00 0x00 0x00 0x00`. There is no need to change the behavior of the master server based on that option, it just needs to allow the different value.

Let me know if there's anything you would like to see changed.